### PR TITLE
Skip cyvcf2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Simple software to call UPD regions from germline exome/wgs trios.
 
 `pip install --editable .` or `python setup.py install`
 
-The only dependencies are cyvcf2, click and coloredlogs. If cyvcf2 does not install please try to install it 
-manually with [bioconda](https://anaconda.org/bioconda/cyvcf2) and then run the command above.
+The only dependencies are click and coloredlogs.
 
 
 ### Input VCF requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 click
-cyvcf2
 coloredlogs

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ DESCRIPTION = 'Simple software to call UPD regions from germline exome/wgs trios
 URL = 'https://github.com/bjhall/upd'
 EMAIL = 'bjorn.hallstrom@skane.se'
 AUTHOR = 'Björn Hallström'
+REQUIRES_PYTHON = '>=3.6'
 VERSION = None
 
 
@@ -136,6 +137,7 @@ setup(
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type='text/markdown',
+    python_requires=REQUIRES_PYTHON,
     author=AUTHOR,
     author_email=EMAIL,
     url=URL,
@@ -155,10 +157,8 @@ setup(
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: 3.6',
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Unix",
         "Intended Audience :: Science/Research",

--- a/tests/test_vcf_tools.py
+++ b/tests/test_vcf_tools.py
@@ -1,7 +1,6 @@
-import cyvcf2
 import pytest
 
-from upd.vcf_tools import (check_samples, get_vcf)
+from upd.vcf_tools import (check_samples, get_vcf, Vcf)
 
 def test_check_samples():
     ## GIVEN a list three samples
@@ -39,7 +38,7 @@ def test_get_vcf(vcf_path):
     vcf_obj = get_vcf(vcf_path, proband, mother, father)
     
     ## THEN assert that vcf_obj has the correct type
-    assert isinstance(vcf_obj, cyvcf2.VCF)
+    assert isinstance(vcf_obj, Vcf)
 
 def test_get_nonexisting_vcf():
     ## GIVEN the path to a non existing VCF and the individuals that should be there
@@ -60,7 +59,7 @@ def test_get_wrong_formated_vcf(ped_path):
     father = 'TEST_FATHER'
     
     ## WHEN getting the vcf
-    with pytest.raises(OSError):
+    with pytest.raises(SyntaxError):
     ## THEN assert a non OSError is raised
         vcf_obj = get_vcf(ped_path, proband, mother, father)
 

--- a/upd/cli.py
+++ b/upd/cli.py
@@ -2,6 +2,7 @@ import logging
 
 import coloredlogs
 import click
+import datetime
 
 from pprint import pprint as pp
 
@@ -76,6 +77,7 @@ def cli(context, vcf, proband, mother, father, af_tag, vep, min_af, min_gq, logl
     LOG.info("Running upd version %s", __version__)
 
     context.obj = {}
+    context.obj['start_time'] = datetime.datetime.now()
     # Check if the given samples IDs exist in the VCF header
     try:
         vcf_reader = get_vcf(vcf, proband, mother, father)
@@ -141,6 +143,9 @@ def regions(context, min_sites, min_size, out):
     with click.open_file(out, 'w') as f:
         for line in out_lines:
             f.write(line+'\n')
+    
+    end_time = datetime.datetime.now() - context.obj['start_time']
+    LOG.info(f"Time to parse variants {end_time}")
 
 
 @cli.command()
@@ -165,3 +170,6 @@ def sites(context, out):
                 scall['pos'],
                 site_type_name[scall['call']]
             ))
+
+    end_time = datetime.datetime.now() - context.obj['start_time']
+    LOG.info(f"Time to parse variants {end_time}")

--- a/upd/cli.py
+++ b/upd/cli.py
@@ -96,11 +96,12 @@ def cli(context, vcf, proband, mother, father, af_tag, vep, min_af, min_gq, logl
             LOG.warning("The field %s does not exist in the VEP annotations", af_tag)
             LOG.info("Existing CSQ fields {}".format('|'.join(csq_fields)))
             context.abort()
+
     else:
         if not vcf_reader.contains(af_tag):
             LOG.warning("The field %s does not exist in the VCF", af_tag)
             context.abort()
-    
+
     # Get all UPD informative sites into a list 
     context.obj['site_calls'] = get_UPD_informative_sites(
         vcf=vcf_reader,

--- a/upd/utils.py
+++ b/upd/utils.py
@@ -58,12 +58,12 @@ def get_UPD_informative_sites(vcf, csq_fields, proband, mother, father, min_af=0
     """Get UPD calls for each informative SNP above given pop freq
     
     Args:
-        vcf (cyvcf2.VCF)
+        vcf (upd.vcf_tools.Vcf)
         min_af (float): Minimum allele frequency to consider SNP
         af_tag (str): Key to AF in annotation
         min_gq (int): Minimum GQ to consider variant
         csq_fields (list): describes VEP annotation
-        sids (cyvcf2.samples): describes what position inds have in VCF
+        sids (list): describes what position inds have in VCF
         proband (str): ID of proband in VCF
         mother (str): ID of mother in VCF
         father (str): ID of father in VCF

--- a/upd/utils.py
+++ b/upd/utils.py
@@ -28,7 +28,6 @@ def upd_site_call(gt_pb, gt_mo, gt_fa):
     """
 
     opposite = {0:3, 3:0}
-    
     # If any of the individuals are 'other' the site is UNINFORMATIVE
     if gt_pb == 2 or gt_mo == 2 or gt_fa == 2:
         return 0

--- a/upd/utils.py
+++ b/upd/utils.py
@@ -38,13 +38,16 @@ def upd_site_call(gt_pb, gt_mo, gt_fa):
         if gt_mo == opp and gt_fa == opp:
             return UNINFORMATIVE
         if gt_mo == opp:
+            LOG.debug("Found paternal upd")
             return UPD_PATERNAL_ORIGIN
         if gt_fa == opp:
+            LOG.debug("Found maternal upd")
             return UPD_MATERNAL_ORIGIN
         return PB_HOMOZYGOUS
         
     if gt_pb == 1:
         if gt_mo != 1 and gt_fa != 1 and gt_mo == opposite[gt_fa]:
+            LOG.debug("Found anti upd")
             return ANTI_UPD
         return PB_HETEROZYGOUS
 

--- a/upd/vcf_tools.py
+++ b/upd/vcf_tools.py
@@ -1,4 +1,204 @@
+import logging
+import gzip
+import re
+
+from codecs import (open, getreader)
+from pprint import pprint as pp
+
 from cyvcf2 import VCF
+
+
+LOG = logging.getLogger(__name__)
+
+
+def open_file(filename):
+    """Open a file and return a iterable with lines"""
+    if filename.endswith('.gz'):
+        LOG.info(f"{filename} is zipped")
+        handle = getreader('utf-8')(gzip.open(filename), errors='replace')
+    else:
+        handle = open(filename, mode='r', encoding='utf-8', errors='replace')
+
+    return handle
+
+
+class Variant(object):
+    """Implements a Variant class for VCF variants
+    
+    gt_types: HOM_REF=0, HET=1, HOM_ALT=2, UKNOWN=3
+    """
+    def __init__(self, variant_line):
+        super(Variant, self).__init__()
+        self.variant_line = variant_line
+        self.CHROM = None
+        self.POS = None
+        self.INFO = {}
+        self.ALT = None
+        self.is_snp = True
+        self.gt_quals = []
+        self.gt_types = []
+        self._initialize()
+    
+    def _initialize(self):
+        splitted_line = self.variant_line.split('\t')
+        self.CHROM = splitted_line[0]
+        self.POS = int(splitted_line[1])
+        self.ALT = splitted_line[4].split(',')
+        if len(splitted_line[3]) != len(splitted_line[4]):
+            self.is_snp = False
+        self.INFO = self._build_info(splitted_line[7])
+        
+        if not len(splitted_line) > 8:
+            return
+        
+        self.gt_quals, self.gt_types = self._build_gt(splitted_line)
+    
+    def _build_gt(self, var_info):
+        """Build the genotype information
+        
+        Collapse the FORMAT information from the 8th column with each individual genotype 
+        information. Then retrieve the genotype call and genotype quality
+        
+        Args:
+             var_info (list): A splited variant line
+        
+        Returns:
+            gt_quals, gt_types (list)
+        
+        """
+        gt_map = {'0/0':0, '0/1':1,'1/1':2}
+        gt_types = []
+        gt_quals = []
+        
+        form = var_info[8].split(':')
+        for ind_info in var_info[9:]:
+            gt_info = dict(zip(form, ind_info.split(':')))
+            gt_quals.append(int(gt_info.get('GQ',0)))
+            genotype = gt_info.get('GT','./.')
+            if not genotype in gt_map:
+                gt_types.append(3)
+                continue
+            gt_types.append(gt_map[genotype])
+        
+        return gt_quals, gt_types
+
+    def _build_info(self, info):
+        """Build a info dictionary from a info str and set self.INFO
+        
+        Args:
+            info (str): Raw vcf info string
+        
+        """
+        info_dict = {}
+        if info == '.':
+            return info_dict
+        for value in info.split(';'):
+            vals = value.split('=')
+            if not len(vals) == 2:
+                info_dict[vals[0]] = True
+                continue
+            info_dict[vals[0]] = vals[1]
+        return info_dict
+    
+    def __str__(self):
+        return self.variant_line
+    
+    def __repr__(self):
+        return f"{self.CHROM}:{self.POS}:{self.gt_types}"
+
+class HREC(object):
+    """VCF header record"""
+    def __init__(self, hid, number=None, htype=None, description=None):
+        super(HREC, self).__init__()
+        self.id = hid
+        self.number = number
+        self.type = htype
+        self.description = description
+    
+    def info(self):
+        """Return the header info in a dictionary"""
+        return {
+            'ID': self.id, 
+            'Number': self.number, 
+            'Type': self.type, 
+            'Description': self.description
+        }
+        
+
+class My_Vcf(object):
+    """Implements a simple vcf parser"""
+    def __init__(self, variant_file):
+        super(My_Vcf, self).__init__()
+        self.variant_file = iter(variant_file)
+        self.raw_header = []
+        self.samples = []
+        self._current_variant = None
+        self._header_keys = set()
+        self._initialize()
+    
+    def _initialize(self):
+        self._parse_header()
+    
+    def _parse_header(self):
+        """docstring for _parse_header"""
+        line = '#'
+        while line.startswith('#'):
+            line = next(self.variant_file)
+            line = line.rstrip()
+            if line.startswith('#'):
+                self.raw_header.append(line)
+                if not line.startswith('##'):
+                    splitted_line = line.split('\t')
+                    if not len(splitted_line) > 9:
+                        raise SyntaxError("No individuals in VCF")
+                    self.samples = splitted_line[9:]
+        self._current_variant = line
+
+    def contains(self, key):
+        """Check if the header contains key"""
+        if not self._header_keys:
+            for rec in self.header_iter():
+                self._header_keys.add(rec.id)
+        
+        return key in self._header_keys
+            
+
+    def header_iter(self):
+        """Iterates over the header lines
+        
+        Creates header records (HREC) for each of the INFO headers
+        
+        Yields:
+            header_record (HREC)
+        """
+        info_pattern = re.compile(r'''\#\#INFO=<
+                    ID=(?P<id>[^,]+),
+                    Number=(?P<number>-?\d+|\.|[AGR]),
+                    Type=(?P<type>Integer|Float|Flag|Character|String),
+                    Description="(?P<desc>[^"]*)"
+                    >''', re.VERBOSE
+                )
+        
+        for header in self.raw_header:
+            if header.startswith('##INFO'):
+                match = info_pattern.match(header)
+                if not match:
+                    raise SyntaxError(f"One of the INFO lines is malformed:{header}")
+                
+                header_record = HREC(match.group('id'), match.group('number'), 
+                                        match.group('type'), match.group('desc'))
+                yield header_record
+    
+    def __next__(self):
+        current_variant = Variant(self._current_variant)
+        self._current_variant = next(self.variant_file).rstrip()
+        return current_variant
+    
+    def __iter__(self):
+        return self
+    
+    def __repr__(self):
+        return f"{self.__class__.__name__}"
 
 def check_samples(sids, proband, mother, father):
     """Check if proband, mother and father exists in vcf
@@ -30,7 +230,9 @@ def get_vcf(vcf_path, proband, mother, father):
         vcf_reader (cyvcf2.VCF)
         
     """
-    vcf_reader = VCF(vcf_path)
+    vcf_handle = open_file(vcf_path)
+    vcf_reader = My_Vcf(vcf_handle)
+    
     if not check_samples(vcf_reader.samples, proband, mother, father):
         raise SyntaxError("At least one of the given sample IDs do not exist in the VCF header")
 

--- a/upd/vcf_tools.py
+++ b/upd/vcf_tools.py
@@ -5,9 +5,6 @@ import re
 from codecs import (open, getreader)
 from pprint import pprint as pp
 
-from cyvcf2 import VCF
-
-
 LOG = logging.getLogger(__name__)
 
 
@@ -25,7 +22,7 @@ def open_file(filename):
 class Variant(object):
     """Implements a Variant class for VCF variants
     
-    gt_types: HOM_REF=0, HET=1, HOM_ALT=2, UKNOWN=3
+    gt_types: 0=HOM_REF, 1=HET, 3=HOM_ALT, 2=other
     """
     def __init__(self, variant_line):
         super(Variant, self).__init__()
@@ -66,7 +63,7 @@ class Variant(object):
             gt_quals, gt_types (list)
         
         """
-        gt_map = {'0/0':0, '0/1':1,'1/1':2}
+        gt_map = {'0/0':0, '0/1':1,'1/1':3}
         gt_types = []
         gt_quals = []
         
@@ -76,7 +73,7 @@ class Variant(object):
             gt_quals.append(int(gt_info.get('GQ',0)))
             genotype = gt_info.get('GT','./.')
             if not genotype in gt_map:
-                gt_types.append(3)
+                gt_types.append(2)
                 continue
             gt_types.append(gt_map[genotype])
         
@@ -125,10 +122,10 @@ class HREC(object):
         }
         
 
-class My_Vcf(object):
-    """Implements a simple vcf parser"""
+class Vcf(object):
+    """Implements a simple vcf parser that mimics parts of cyvcf2.VCF"""
     def __init__(self, variant_file):
-        super(My_Vcf, self).__init__()
+        super(Vcf, self).__init__()
         self.variant_file = iter(variant_file)
         self.raw_header = []
         self.samples = []
@@ -198,7 +195,7 @@ class My_Vcf(object):
         return self
     
     def __repr__(self):
-        return f"{self.__class__.__name__}"
+        return f"{self.__class__.__name__} ({self.samples})"
 
 def check_samples(sids, proband, mother, father):
     """Check if proband, mother and father exists in vcf
@@ -231,7 +228,7 @@ def get_vcf(vcf_path, proband, mother, father):
         
     """
     vcf_handle = open_file(vcf_path)
-    vcf_reader = My_Vcf(vcf_handle)
+    vcf_reader = Vcf(vcf_handle)
     
     if not check_samples(vcf_reader.samples, proband, mother, father):
         raise SyntaxError("At least one of the given sample IDs do not exist in the VCF header")

--- a/upd/vcf_tools.py
+++ b/upd/vcf_tools.py
@@ -70,7 +70,12 @@ class Variant(object):
         form = var_info[8].split(':')
         for ind_info in var_info[9:]:
             gt_info = dict(zip(form, ind_info.split(':')))
-            gt_quals.append(int(gt_info.get('GQ',0)))
+            gq = 0
+            try:
+                gq = int(gt_info.get('GQ',0))
+            except Exception as err:
+                pass
+            gt_quals.append(gq)
             genotype = gt_info.get('GT','./.')
             if not genotype in gt_map:
                 gt_types.append(2)

--- a/upd/vcf_tools.py
+++ b/upd/vcf_tools.py
@@ -224,7 +224,7 @@ def get_vcf(vcf_path, proband, mother, father):
         father (str): ID of father in VCF
     
     Returns:
-        vcf_reader (cyvcf2.VCF)
+        vcf_reader (Vcf)
         
     """
     vcf_handle = open_file(vcf_path)
@@ -256,7 +256,7 @@ def parse_CSQ_header(reader):
     """Parse the order of VEP fields from the vcf header
     
     Args:
-        reader (cyvcf2.VCF)
+        reader (Vcf)
 
     Returns:
         csq_format (list(str)): A list with the VEP header
@@ -275,7 +275,7 @@ def get_pop_AF(variant, vep_fields, af_tag):
     """Extract population frequency from VEP annotations.
     
     Args:
-        variant (cyvcf2.Variant)
+        variant (Variant)
         vep_fields (list): Description of VEP annotation
         af_tag (str): Name of AF field to parse
     


### PR DESCRIPTION
Hi,

I think cyvcf2 is fantastic to parse VCFs but there are almost always small problems during installation, especially if one not uses conda. I implemented some classes that mocks some of the behaviour that cyvcf2 has so the rest of the code does not need to change. In this way it is possible to switch back to using cyvcf2 anytime if there is a need for it.
The whole package becomes more light weight and is actually a little bit faster now since there are many steps in the VCF parsing that is skipped.