### PR TITLE
Feature iso hom pct 201127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+- Add argument to change the homozygozity rate cutoff for calling isodisomies
 ### Fixed
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ base | **--vep (flag)** | If given, search the CSQ field for `af-tag`
 regions | **--min-sites (DEFAULT: 3)** | Minimum number of consecutive UPD sites needed to call an UPD region.
 regions | **--min-size (DEFAULT: 1000)** | Minimum number of base pairs between first and last UPD site in a region required to call it.
 regions/sites | **--out (DEFAULT: stdout)** | If the results should be printed to a file
-regions/sites | **--iso_het_pct (DEFAULT: 0.01)** | Threshold ratio for calling homodisomy
+regions/sites | **--iso-het-pct (DEFAULT: 0.01)** | Threshold ratio for calling homodisomy
 
 
 ### Output

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ base | **--vep (flag)** | If given, search the CSQ field for `af-tag`
 regions | **--min-sites (DEFAULT: 3)** | Minimum number of consecutive UPD sites needed to call an UPD region.
 regions | **--min-size (DEFAULT: 1000)** | Minimum number of base pairs between first and last UPD site in a region required to call it.
 regions/sites | **--out (DEFAULT: stdout)** | If the results should be printed to a file
+regions/sites | **--iso_het_pct (DEFAULT: 0.01)** | Threshold ratio for calling homodisomy
 
 
 ### Output

--- a/upd/bed_utils.py
+++ b/upd/bed_utils.py
@@ -1,12 +1,12 @@
 
-def output_filtered_regions(calls, min_sites=3, min_size=1000):
+def output_filtered_regions(calls, min_sites=3, min_size=1000, iso_het_pct=0.01):
     """Takes called regions, filters them, and yields annotated BED lines
-    
+
     Args:
         calls (iterable): An iterable with UPD regions
         min_sites (int): Minimum UPD informative sites required to call a region
         min_size (int): Minimum size (bp) required to call a region
-    
+        iso_het_pct(float): Quota between het-sites and hom-sties
     Yields:
         out_line (str): A formated string with the information about a region
     """
@@ -23,7 +23,7 @@ def output_filtered_regions(calls, min_sites=3, min_size=1000):
         # Rough estimation if heterodisomy or homodisomy/deletion
         het_pct = float(rcall['het_sites']) / float((rcall['het_sites']+rcall['hom_sites']))
         upd_type = "HETERODISOMY"
-        if het_pct < 0.01:
+        if het_pct < iso_het_pct:
             upd_type = "HOMODISOMY/DELETION"
 
         if lo_size < min_size:

--- a/upd/cli.py
+++ b/upd/cli.py
@@ -134,7 +134,7 @@ def cli(context, vcf, proband, mother, father, af_tag, vep, min_af, min_gq, logl
     default='-',
 )
 
-@click.option('--iso_het_pct',
+@click.option('--iso-het-pct',
     help="Ratio iso/het for determening UPD type",
     default=0.01,
     show_default=True


### PR DESCRIPTION
Add possible argument to control ratio for calling homozygosity. Defaults to 0.01 as previous behaviour.

Test:
```
upd --vcf tests/fixtures/test.vcf.gz  --proband TEST_PROBAND --mother TEST_MOTHER --father TEST_FATHER  --vep regions --iso-het-pct 0.05

```

[ ] Update changelog