### PR TITLE
Fix issue with missing INFO field due to '=' in annotation field

### DIFF
--- a/upd/vcf_tools.py
+++ b/upd/vcf_tools.py
@@ -96,10 +96,11 @@ class Variant(object):
             return info_dict
         for value in info.split(';'):
             vals = value.split('=')
-            if not len(vals) == 2:
-                info_dict[vals[0]] = True
-                continue
-            info_dict[vals[0]] = vals[1]
+            # if not len(vals) == 2:
+            #     info_dict[vals[0]] = True
+            #     continue
+            # info_dict[vals[0]] = vals[1]
+            info_dict[vals[0]] = value.lstrip(vals[0] + "=")
         return info_dict
     
     def __str__(self):


### PR DESCRIPTION
Resolved a parsing error where annotations containing '=' caused INFO fields to be inaccessible. This fix ensures that INFO fields are correctly extracted regardless of annotation content.

This bug occurs because VEP may add annotations with "=" symbols, like in HGVSp for synonymous mutations. When this happens, the INFO field in the parsed dictionary gets set to True instead of the expected value. As a result, when we later try to use split("|") on the INFO content, it fails because the data isn’t in the expected format.